### PR TITLE
Prow migration and deploy to test/prod cluster

### DIFF
--- a/hack/build-deploy-app.sh
+++ b/hack/build-deploy-app.sh
@@ -12,7 +12,9 @@ unzip DB11.ZIP -d DB11
 mv DB11/IP2LOCATION-LITE-DB11.IPV6.BIN DB11.BIN
 rm -rf DB11.ZIP DB11
 
-plantbuild push ./plantbuild/build.jsonnet
+export IMAGE_TAG="$(date "+%Y%m%d")"
+
+plantbuild push ./plantbuild/build.jsonnet -v "$IMAGE_TAG"
 
 ./hack/deploy-to-cluster.sh test "ssh -o StrictHostKeychecking=no ubuntu@bastion.test.shared.k8s.theplant.dev /bin/bash"
 

--- a/hack/build-deploy-app.sh
+++ b/hack/build-deploy-app.sh
@@ -15,4 +15,13 @@ rm -rf DB11.ZIP DB11
 plantbuild push ./plantbuild/build.jsonnet
 
 ./hack/deploy-to-cluster.sh test "ssh -o StrictHostKeychecking=no ubuntu@bastion.test.shared.k8s.theplant.dev /bin/bash"
-# ./deploy-to-cluster.sh prod "ssh -o StrictHostKeychecking=no ubuntu@bastion.prod.aigle.k8s.theplant.dev /bin/bash"
+
+TEST_VALIDATION=$(curl -I -m 3 -s -H 'IP2Location-IP: 1.1.1.1' -i https://ip2location-test.theplant-dev.com | awk 'BEGIN {FS=": "}/^ip2location-country-code/{print $2}')
+
+if [ "$TEST_VALIDATION" == "US" ]; 
+  then
+    ./deploy-to-cluster.sh prod "ssh -o StrictHostKeychecking=no ubuntu@bastion.prod.aigle.k8s.theplant.dev /bin/bash"
+  else
+    echo "Test cluster deploy failed, will NOT continue deploy to Prod cluster!!!"
+    exit 1
+fi

--- a/hack/build-deploy-app.sh
+++ b/hack/build-deploy-app.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck disable=SC1091
+source hack/get-tools.sh
+
+curl -fSL -o DB11.ZIP "http://www.ip2location.com/download/?token=${DOWNLOAD_TOKEN}&file=DB11LITEBINIPV6"
+unzip DB11.ZIP -d DB11
+mv DB11/IP2LOCATION-LITE-DB11.IPV6.BIN DB11.BIN
+rm -rf DB11.ZIP DB11
+
+plantbuild push ./plantbuild/build.jsonnet
+
+./hack/deploy-to-cluster.sh test "ssh -o StrictHostKeychecking=no ubuntu@bastion.test.shared.k8s.theplant.dev /bin/bash"
+# ./deploy-to-cluster.sh prod "ssh -o StrictHostKeychecking=no ubuntu@bastion.prod.aigle.k8s.theplant.dev /bin/bash"

--- a/hack/build-deploy-app.sh
+++ b/hack/build-deploy-app.sh
@@ -12,6 +12,8 @@ unzip DB11.ZIP -d DB11
 mv DB11/IP2LOCATION-LITE-DB11.IPV6.BIN DB11.BIN
 rm -rf DB11.ZIP DB11
 
+docker login --username=sunfmin --password=$DOCKER_HUB_PASSWORD
+
 export IMAGE_TAG="$(date "+%Y%m%d")"
 
 plantbuild push ./plantbuild/build.jsonnet -v "$IMAGE_TAG"

--- a/hack/build-deploy-app.sh
+++ b/hack/build-deploy-app.sh
@@ -18,9 +18,9 @@ plantbuild push ./plantbuild/build.jsonnet -v "$IMAGE_TAG"
 
 ./hack/deploy-to-cluster.sh test "ssh -o StrictHostKeychecking=no ubuntu@bastion.test.shared.k8s.theplant.dev /bin/bash"
 
-TEST_VALIDATION=$(curl -I -m 3 -s -H 'IP2Location-IP: 1.1.1.1' -i https://ip2location-test.theplant-dev.com | awk 'BEGIN {FS=": "}/^ip2location-country-code/{print $2}')
+TEST_COUNTRY_CODE=$(curl -I -m 3 -s -H 'IP2Location-IP: 1.1.1.1' -i https://ip2location-test.theplant-dev.com | awk 'BEGIN {FS=": "}/^ip2location-country-code/{print $2}')
 
-if [ "$TEST_VALIDATION" == "US" ]; 
+if [ "$TEST_COUNTRY_CODE" == "US" ]; 
   then
     ./deploy-to-cluster.sh prod "ssh -o StrictHostKeychecking=no ubuntu@bastion.prod.aigle.k8s.theplant.dev /bin/bash"
   else

--- a/hack/build-deploy-app.sh
+++ b/hack/build-deploy-app.sh
@@ -12,8 +12,6 @@ unzip DB11.ZIP -d DB11
 mv DB11/IP2LOCATION-LITE-DB11.IPV6.BIN DB11.BIN
 rm -rf DB11.ZIP DB11
 
-docker login --username=sunfmin --password=$DOCKER_HUB_PASSWORD
-
 export IMAGE_TAG="$(date "+%Y%m%d")"
 
 plantbuild push ./plantbuild/build.jsonnet -v "$IMAGE_TAG"

--- a/hack/deploy-to-cluster.sh
+++ b/hack/deploy-to-cluster.sh
@@ -29,7 +29,7 @@ if [ "$JOB_TYPE" == "periodics" ]; then
   plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet -d server
 fi
 
-plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet
+plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet -v "$IMAGE_TAG"
 
 # consider to move this functionality to plantbuild
 if [ -z "$KUBECTL_BASH" ]; then

--- a/hack/deploy-to-cluster.sh
+++ b/hack/deploy-to-cluster.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+CLUSTER=${1}
+KUBECTL_BASH=${2}
+
+# if no cluster aliases provided, display the usage and exit
+if [ "$CLUSTER" == "" ]; then
+  echo "Usage: CLUSTER=test or prod $0"
+  exit
+fi
+
+# assuming we already have kubectl and plantbuild installed on macos
+# shellcheck disable=SC1091
+if [ "$(uname)" != "Darwin" ]; then
+  source hack/get-tools.sh
+else
+  echo "looks like you are running this on your laptop, see comments to set KUBECTL_BASH for clusters behind bastion"
+  # modify and uncommet the export statement to set bastion excuting
+  # assuming we have access to the bastion server and it has kubectl and kubeconfig installed
+  # export KUBECTL_BASH="ssh -o StrictHostKeychecking=no ubuntu@bastion.foobar.theplant.dev /bin/bash"
+fi
+
+allows CI presubmit jobs to test by dry-running
+if [ "$JOB_TYPE" == "periodics" ]; then
+  plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet -d client
+  plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet -d server
+  exit
+fi
+
+plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet
+
+# consider to move this functionality to plantbuild
+if [ -z "$KUBECTL_BASH" ]; then
+  KUBECTL_BASH="/bin/bash"
+fi
+
+NAMESPACE="ip2location-$CLUSTER"
+COMMAND="kubectl -n $NAMESPACE get deploy -o name |
+          xargs -n1 \
+            kubectl -n $NAMESPACE rollout status --timeout 150s"
+
+echo "$COMMAND" | $KUBECTL_BASH

--- a/hack/deploy-to-cluster.sh
+++ b/hack/deploy-to-cluster.sh
@@ -27,7 +27,6 @@ allows CI presubmit jobs to test by dry-running
 if [ "$JOB_TYPE" == "periodics" ]; then
   plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet -d client
   plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet -d server
-  exit
 fi
 
 plantbuild k8s_apply ./plantbuild/"$CLUSTER"/all.jsonnet

--- a/hack/get-tools.sh
+++ b/hack/get-tools.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+curl -L https://raw.githubusercontent.com/theplant/plantbuild/master/plantbuild > ./pb \
+  && chmod +x ./pb \
+  && mv ./pb /usr/local/bin/plantbuild
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl \
+  && chmod +x ./kubectl \
+  && mv ./kubectl /usr/local/bin/kubectl
+
+kubectl version --client 

--- a/plantbuild/build.jsonnet
+++ b/plantbuild/build.jsonnet
@@ -1,9 +1,9 @@
 local dc0 = import 'dc.jsonnet';
 
 local dc = dc0 {
-  dockerRegistry: 'registry.hub.docker.com',
+  dockerRegistry: '562055475000.dkr.ecr.ap-northeast-1.amazonaws.com',
 };
 
-dc.build_apps_image('/theplant', [
+dc.build_apps_image('public/ip2location-nginx', [
   { name: 'ip2location-nginx', context: './', dockerfile: './Dockerfile' },
 ])

--- a/plantbuild/build.jsonnet
+++ b/plantbuild/build.jsonnet
@@ -1,0 +1,9 @@
+local dc0 = import 'dc.jsonnet';
+
+local dc = dc0 {
+  dockerRegistry: 'registry.hub.docker.com',
+};
+
+dc.build_apps_image('/theplant', [
+  { name: 'ip2location-nginx', context: './', dockerfile: './Dockerfile' },
+])

--- a/plantbuild/prod/all.jsonnet
+++ b/plantbuild/prod/all.jsonnet
@@ -1,0 +1,8 @@
+local k8s = import 'k8s.jsonnet';
+
+k8s.list([
+  k8s.namespace(
+    name='ip2location',
+  ),
+  import './ip2location.jsonnet',
+])

--- a/plantbuild/prod/ip2location.jsonnet
+++ b/plantbuild/prod/ip2location.jsonnet
@@ -8,7 +8,7 @@ k8s.image_to_url(
   port=8080,
   targetPort=8080,
   imagePullSecrets='',
-  image='theplant/ip2location-nginx:latest',
+  image='theplant/ip2location-nginx',
   ingressTLSEnabled=true,
   ingressAnnotations={
     'kubernetes.io/ingress.class': 'nginx',

--- a/plantbuild/prod/ip2location.jsonnet
+++ b/plantbuild/prod/ip2location.jsonnet
@@ -1,0 +1,18 @@
+local k8s = import 'k8s.jsonnet';
+
+k8s.image_to_url(
+  namespace='ip2location-prod',
+  name='ip2location',
+  host='ip2location-prod.theplant-dev.com',
+  path='/',
+  port=8080,
+  targetPort=8080,
+  imagePullSecrets='',
+  image='theplant/ip2location-nginx:latest',
+  ingressTLSEnabled=true,
+  ingressAnnotations={
+    'kubernetes.io/ingress.class': 'nginx',
+    'kubernetes.io/tls-acme': 'true',
+    'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
+  },
+)

--- a/plantbuild/test/all.jsonnet
+++ b/plantbuild/test/all.jsonnet
@@ -1,0 +1,8 @@
+local k8s = import 'k8s.jsonnet';
+
+k8s.list([
+  k8s.namespace(
+    name='ip2location',
+  ),
+  import './ip2location.jsonnet',
+])

--- a/plantbuild/test/ip2location.jsonnet
+++ b/plantbuild/test/ip2location.jsonnet
@@ -8,7 +8,7 @@ k8s.image_to_url(
   port=8080,
   targetPort=8080,
   imagePullSecrets='',
-  image='theplant/ip2location-nginx:latest',
+  image='theplant/ip2location-nginx',
   ingressTLSEnabled=true,
   ingressAnnotations={
     'kubernetes.io/ingress.class': 'nginx',

--- a/plantbuild/test/ip2location.jsonnet
+++ b/plantbuild/test/ip2location.jsonnet
@@ -1,0 +1,18 @@
+local k8s = import 'k8s.jsonnet';
+
+k8s.image_to_url(
+  namespace='ip2location-test',
+  name='ip2location',
+  host='ip2location-test.theplant-dev.com',
+  path='/',
+  port=8080,
+  targetPort=8080,
+  imagePullSecrets='',
+  image='theplant/ip2location-nginx:latest',
+  ingressTLSEnabled=true,
+  ingressAnnotations={
+    'kubernetes.io/ingress.class': 'nginx',
+    'kubernetes.io/tls-acme': 'true',
+    'cert-manager.io/cluster-issuer': 'letsencrypt',
+  },
+)

--- a/plantbuild/test/ip2location.jsonnet
+++ b/plantbuild/test/ip2location.jsonnet
@@ -8,7 +8,7 @@ k8s.image_to_url(
   port=8080,
   targetPort=8080,
   imagePullSecrets='',
-  image='theplant/ip2location-nginx',
+  image='562055475000.dkr.ecr.ap-northeast-1.amazonaws.com/public/ip2location-nginx',
   ingressTLSEnabled=true,
   ingressAnnotations={
     'kubernetes.io/ingress.class': 'nginx',


### PR DESCRIPTION
Build and deploy to both test and prod cluster periodically. (Every Mon UTC 19:00).

Test cluster:
```
(⎈ test.shared.k8s.theplant.dev:ip2location-test)ip2location-nginx git:sre-759-migrate-to-test ➜ curl -H 'IP2Location-IP: 218.250.86.186' -i https://ip2location-test.theplant-dev.com
HTTP/1.1 200 Connection established
Connection: close

HTTP/2 200
date: Mon, 23 Aug 2021 07:13:48 GMT
content-type: application/octet-stream
content-length: 2
ip2location-country-code: HK
ip2location-country-name: Hong Kong
ip2location-region: Hong Kong
ip2location-city: Tan Shan Tsuen
ip2location-latitude: 22.333330
ip2location-longitude: 114.233330
ip2location-zipcode: -
ip2location-timezone: +08:00
strict-transport-security: max-age=15724800; includeSubDomains

OK%
(⎈ test.shared.k8s.theplant.dev:ip2location-test)ip2location-nginx git:sre-759-migrate-to-test ➜
```