### PR TITLE
chore: replace Dependabot reviewer with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @theplant/sre

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "base-image/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "theplant/sre"


### PR DESCRIPTION
The `reviewers` config is deprecated by CODEOWNERS
xRef: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/